### PR TITLE
fix spec for signing

### DIFF
--- a/lib/signex.ex
+++ b/lib/signex.ex
@@ -154,7 +154,7 @@ defmodule SignEx do
 
 
   @spec sign_message(binary, digest :: atom, keypair :: map)
-  :: {:ok, {key_id :: String.t, signature :: String.t}} | {:error, atom}
+  :: {:ok, signature :: String.t} | {:error, atom}
 
   def sign_message(message, digest, %{public_key: _public_key, private_key: private_key}) do
     if digest in Algorithm.available_digests() do


### PR DESCRIPTION
@nietaki I think this is correct.

As I started from the spec as docs and It led me astray I still think we need to use dialyzer to ensure that we dont end up with stale docs(specs)